### PR TITLE
Add ability to stop downloads in progress

### DIFF
--- a/redditdownloader/interfaces/eelwrapper.py
+++ b/redditdownloader/interfaces/eelwrapper.py
@@ -279,6 +279,17 @@ def start_download():
 		print('Started downloader.')
 		return True
 
+@eel.expose
+def stop_download():
+	global _controller
+	if _controller is not None and _controller.is_running():
+		_controller.stop()
+		_controller = None
+		print('Stopped downloader.')
+		return True
+	else:
+		return False
+
 
 @eel.expose
 def download_status():

--- a/redditdownloader/processing/controller.py
+++ b/redditdownloader/processing/controller.py
@@ -9,6 +9,7 @@ from processing.downloader import Downloader
 from processing.post_processing import Deduplicator
 from processing.wrappers import ProgressManifest
 from multiprocessing import RLock
+import time
 
 
 class RMDController(threading.Thread):
@@ -40,15 +41,17 @@ class RMDController(threading.Thread):
 	def stop(self):
 		# Set the stop event for all threads, so there's no new work
 		self.loader.get_stop_event().set()
-		# Give each downloader 2 seconds to finish it's current task (max len(self._downloaders) * 2 seconds)
+		# Record what time we want to be done by (now + 5 seconds)
+		# Gives the downloaders up to 5 seconds from now to finish their current tasks
+		max_time = time.time() + 5
 		for d in self._downloaders:
 			# if the join times out, whatever is running will be re-downloaded when downloading starts again
 			# since the database is updated on completion
-			d.join(2)
+			d.join(max(0, max_time - time.time()))
 			if d.is_alive():
 				# Downloader thread did not stop in time, so we help it along
 				d.terminate()
-		# will also terminate any deduplicator thread as well.
+		# Also terminate any running deduplicator threads
 		self.loader.terminate()
 
 	def is_running(self):

--- a/redditdownloader/processing/controller.py
+++ b/redditdownloader/processing/controller.py
@@ -40,9 +40,11 @@ class RMDController(threading.Thread):
 	def stop(self):
 		# Set the stop event for all threads, so there's no new work
 		self.loader.get_stop_event().set()
-		# Wait for each downloader to finish it's current task
+		# Give each downloader 2 seconds to finish it's current task (max len(self._downloaders) * 2 seconds)
 		for d in self._downloaders:
-			d.join()
+			# if the join times out, whatever is running will be re-downloaded when downloading starts again
+			# since the database is updated on completion
+			d.join(2)
 		# will also terminate any deduplicator thread as well.
 		self.loader.terminate()
 

--- a/redditdownloader/processing/controller.py
+++ b/redditdownloader/processing/controller.py
@@ -45,6 +45,9 @@ class RMDController(threading.Thread):
 			# if the join times out, whatever is running will be re-downloaded when downloading starts again
 			# since the database is updated on completion
 			d.join(2)
+			if d.is_alive():
+				# Downloader thread did not stop in time, so we help it along
+				d.terminate()
 		# will also terminate any deduplicator thread as well.
 		self.loader.terminate()
 

--- a/redditdownloader/processing/controller.py
+++ b/redditdownloader/processing/controller.py
@@ -43,6 +43,7 @@ class RMDController(threading.Thread):
 		# Wait for each downloader to finish it's current task
 		for d in self._downloaders:
 			d.join()
+		# will also terminate any deduplicator thread as well.
 		self.loader.terminate()
 
 	def is_running(self):

--- a/redditdownloader/processing/controller.py
+++ b/redditdownloader/processing/controller.py
@@ -38,9 +38,11 @@ class RMDController(threading.Thread):
 		[t.join() for t in self._all_processes]
 
 	def stop(self):
+		# Set the stop event for all threads, so there's no new work
 		self.loader.get_stop_event().set()
+		# Wait for each downloader to finish it's current task
 		for d in self._downloaders:
-			d.terminate()
+			d.join()
 		self.loader.terminate()
 
 	def is_running(self):

--- a/redditdownloader/web/js/App.js
+++ b/redditdownloader/web/js/App.js
@@ -5,6 +5,7 @@ class App extends React.Component {
 		let current = 0;
 		this._openPage = this.openPage.bind(this);
 		this._start_download = this.startDownload.bind(this);
+		this._stop_download = this.stopDownload.bind(this);
 		this.pages = [
 			// [Element, Name, enabled_while_running]
 			[<Home />, 'Home', true],
@@ -75,6 +76,21 @@ class App extends React.Component {
 		});
 	}
 
+	stopDownload(evt){
+		evt.preventDefault();
+		if(!this.state.downloading)
+			return;
+		console.log('Stopping RMD download process!');
+		eel.stop_download()(n => {
+			if (n) {
+				clearTimeout(this.check_timer);
+				this.checkStatus();
+			} else {
+				alertify.error('Unable to stop RMD downloading - Is it already stopped?')
+			}
+		});
+	}
+
 	render() {
 		let pages = this.pages.map((p, idx)=>{
 			if(this.state.downloading && this.pages[idx][2] === false){
@@ -89,8 +105,8 @@ class App extends React.Component {
 			let idx = this.pages.indexOf(p);
 			return <div key={idx} className={this.state.page === idx? 'active_page_container':'hidden'} >{p[0]}</div>
 		});
-		let run_btn = <li className={'right ' + (this.state.downloading ? 'disabled' : 'special')} key={'dl_button'}>
-			<a onClick={this._start_download}>{this.state.downloading?'Downloading...':'Start Downloading!'}</a>
+		let run_btn = <li className={'right ' + ('special')} key={'dl_button'}>
+			<a onClick={this.state.downloading?this._stop_download : this._start_download}>{this.state.downloading?'Downloading... STOP?':'Start Downloading!'}</a>
 		</li>;
 
 		return (


### PR DESCRIPTION
Related to issue #90 and #94 

This set of changes allows the user to stop downloads in progress.
When downloading is started, the start button becomes a stop button instead of becoming disabled.

When pressed, the stop button closes the download queue, then joins the running downloader threads, before stopping the loader thread as well.  When the loader is terminated, it should also stop the deduplicator thread, which we may or may not want to happen.  

As long as the deduplicator thread isn't double started, I think it should continue to run in the background instead of being canceled.

