### PR TITLE
changes youtube-dl to yt-dlp fixing redgif downloads

### DIFF
--- a/redditdownloader/processing/handlers/ytdl.py
+++ b/redditdownloader/processing/handlers/ytdl.py
@@ -1,4 +1,4 @@
-import youtube_dl
+import yt_dlp
 import os
 import sys
 from processing.handlers import HandlerResponse
@@ -57,7 +57,7 @@ class YTDLWrapper:
 		}
 		failed = False
 		try:
-			with youtube_dl.YoutubeDL(ydl_opts) as ydl:
+			with yt_dlp.YoutubeDL(ydl_opts) as ydl:
 				self.progress.set_status("Looking for video...")
 				ydl.download([url])
 		except Exception as ex:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 psaw~=0.0.12
-youtube_dl
+yt-dlp
 imgurpython==1.1.7
 requests>=2.22.0
 sqlalchemy==1.3.23


### PR DESCRIPTION
Fixes downloads for redgifs.com by replacing the download library.

Example error:
https://github.com/shadowmoose/RedditDownloader/issues/261